### PR TITLE
fix(video_ext): 🐛 修复文件名后缀配置不生效问题

### DIFF
--- a/pkg/util.go
+++ b/pkg/util.go
@@ -244,7 +244,7 @@ func IsWantedVideoExtDef(fileName string) bool {
 		_wantedExtMap[common.VideoExtIso] = common.VideoExtIso
 		_wantedExtMap[common.VideoExtM2ts] = common.VideoExtM2ts
 
-		for _, videoExt := range _customVideoExts {
+		for _, videoExt := range settings.Get().AdvancedSettings.CustomVideoExts {
 			_wantedExtMap[videoExt] = videoExt
 		}
 	}
@@ -732,5 +732,4 @@ func GetMaxSizeFile(path string) string {
 var (
 	_wantedExtMap    = make(map[string]string) // 人工确认的需要监控的视频后缀名
 	_defExtMap       = make(map[string]string) // 内置支持的视频后缀名列表
-	_customVideoExts = make([]string, 0)       // 用户额外自定义的视频后缀名列表
 )


### PR DESCRIPTION
修复 https://github.com/ChineseSubFinder/ChineseSubFinder/issues/650 

改了代码，功能符合预期了。 不过不确定这样实现是否ok。

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/29500388/230951899-a75d97a2-a8eb-4ffc-bb04-9b9e051e328a.png">